### PR TITLE
Removed pinning of spring-hateoas version, upgraded to most recent ve…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 plugins {
   id "org.jetbrains.kotlin.jvm" version "1.2.71"
   id "org.jetbrains.kotlin.plugin.spring" version "1.2.71"
-  id 'org.springframework.boot' version '2.0.4.RELEASE'
+  id 'org.springframework.boot' version '2.0.6.RELEASE'
   id 'org.jlleitschuh.gradle.ktlint' version '4.0.0'
 }
 
@@ -53,12 +53,6 @@ dependencyManagement {
     mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:2.0.0.RELEASE"
   }
 }
-
-// spring boot > 2.0.4 upgrades spring hateoas to version 0.25.0.RELEASE. This version changes how the ObjectMapper
-// that spring hateoas uses for generating hal+json is configured, and breaks the current format of the responses.
-// So, when upgrading to spring-hateoas 0.25.0 and beyond, be prepared to do some work with the serialization
-// configuration (see ApplicationConfig).
-ext['spring-hateoas.version'] = '0.24.0.RELEASE'
 
 def junitJupiterVersion = dependencyManagement.importedProperties['junit-jupiter.version']
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,8 @@ dependencies {
   )
 
   [
-      'org.spockframework:spock-core:1.1-groovy-2.4',
-      'org.spockframework:spock-spring:1.1-groovy-2.4',
+      'org.spockframework:spock-core:1.2-groovy-2.4',
+      'org.spockframework:spock-spring:1.2-groovy-2.4',
       'org.springframework.restdocs:spring-restdocs-mockmvc',
       'org.springframework.security:spring-security-test',
       'org.junit.jupiter:junit-jupiter-api',

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/ObjectMapperConfigurer.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/ObjectMapperConfigurer.kt
@@ -2,14 +2,23 @@
 
 package no.skatteetaten.aurora.mokey
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.hateoas.hal.Jackson2HalModule
+
+fun createObjectMapper() =
+    configureObjectMapper(ObjectMapper())
 
 fun configureObjectMapper(objectMapper: ObjectMapper): ObjectMapper {
-    return objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-            .configure(SerializationFeature.INDENT_OUTPUT, true)
-            .registerModules(JavaTimeModule())
-            .registerKotlinModule()
+    return objectMapper.apply {
+        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        configure(SerializationFeature.INDENT_OUTPUT, true)
+        registerModules(JavaTimeModule(), Jackson2HalModule())
+        registerKotlinModule()
+        enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+        disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationController.kt
@@ -5,6 +5,7 @@ import no.skatteetaten.aurora.mokey.service.ApplicationDataService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.hateoas.ExposesResourceFor
+import org.springframework.hateoas.Resources
 import org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport
 import org.springframework.web.bind.annotation.GetMapping
@@ -31,9 +32,9 @@ class ApplicationController(val applicationDataService: ApplicationDataService) 
     fun getApplications(
         @RequestParam(required = false, defaultValue = "", name = "affiliation") affiliation: List<String>,
         @RequestParam(required = false, defaultValue = "", name = "id") id: List<String>
-    ): List<ApplicationResource> {
+    ): Resources<ApplicationResource> {
         val allApplicationData = applicationDataService.findAllPublicApplicationData(affiliation, id)
-        return assembler.toResources(GroupedApplicationData.create(allApplicationData))
+        return Resources(assembler.toResources(GroupedApplicationData.create(allApplicationData)))
     }
 }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentDetailsController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentDetailsController.kt
@@ -13,6 +13,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.hateoas.ExposesResourceFor
 import org.springframework.hateoas.Link
+import org.springframework.hateoas.Resources
 import org.springframework.hateoas.mvc.ControllerLinkBuilder
 import org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport
@@ -41,12 +42,11 @@ class ApplicationDeploymentDetailsController(
             ?: throw NoSuchResourceException("Does not exist")
 
     @GetMapping
-
     fun getAll(
         @RequestParam(required = false, defaultValue = "", name = "affiliation") affiliation: List<String>,
         @RequestParam(required = false, defaultValue = "", name = "id") id: List<String>
-    ): List<ApplicationDeploymentDetailsResource> =
-        assembler.toResources(applicationDataService.findAllApplicationData(affiliation, id))
+    ): Resources<ApplicationDeploymentDetailsResource> =
+        Resources(assembler.toResources(applicationDataService.findAllApplicationData(affiliation, id)))
 }
 
 @Component

--- a/src/test/groovy/no/skatteetaten/aurora/mokey/contracts/AbstractContractBase.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/mokey/contracts/AbstractContractBase.groovy
@@ -76,11 +76,9 @@ abstract class AbstractContractBase extends Specification {
   }
 
   def setupMockMvc(Object controller) {
-    def objectMapper = ObjectMapperConfigurer.configureObjectMapper(new ObjectMapper())
-    objectMapper.registerModule(new Jackson2HalModule())
+    def objectMapper = ObjectMapperConfigurer.createObjectMapper()
     objectMapper.setHandlerInstantiator(
         new Jackson2HalModule.HalHandlerInstantiator(new AnnotationRelProvider(), null, null, new HalConfiguration()))
-
 
     def converter = new MappingJackson2HttpMessageConverter()
     converter.setObjectMapper(objectMapper)

--- a/src/test/resources/contracts/application/responses/applications.json
+++ b/src/test/resources/contracts/application/responses/applications.json
@@ -1,36 +1,40 @@
-[
-  {
-    "identifier": "abc123",
-    "name": "name",
-    "tags": [],
-    "applicationDeployments": [
+{
+  "_embedded": {
+    "applicationResourceList": [
       {
-        "identifier": "abc1234",
+        "identifier": "abc123",
         "name": "name",
-        "affiliation": "paas",
-        "environment": "utv",
-        "namespace": "paas-utv",
-        "status": {
-          "code": "HEALTHY",
-          "comment": ""
-        },
-        "version": {
-          "deployTag": ""
-        },
-        "_links" : {
-          "self" : {
-            "href" : "http://localhost/api/applicationdeployment/abc1234"
-          },
-          "ApplicationDeploymentDetails" : {
-            "href" : "http://localhost/api/auth/applicationdeploymentdetails/abc1234"
+        "tags": [],
+        "applicationDeployments": [
+          {
+            "identifier": "abc1234",
+            "name": "name",
+            "affiliation": "paas",
+            "environment": "utv",
+            "namespace": "paas-utv",
+            "status": {
+              "code": "HEALTHY",
+              "comment": ""
+            },
+            "version": {
+              "deployTag": ""
+            },
+            "_links": {
+              "self": {
+                "href": "http://localhost/api/applicationdeployment/abc1234"
+              },
+              "ApplicationDeploymentDetails": {
+                "href": "http://localhost/api/auth/applicationdeploymentdetails/abc1234"
+              }
+            }
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "http://localhost/api/application/abc123"
           }
         }
       }
-    ],
-    "_links": {
-      "self": {
-        "href": "http://localhost/api/application/abc123"
-      }
-    }
+    ]
   }
-]
+}


### PR DESCRIPTION
…rsion and made proper adjustments. Contract tests still not upgraded.

This task is kind of painfull to resolve completely. All it takes to use the hal ObjectMapper in the most recent versions of spring-hateoas is to upgrade and remove all custom config. Every controller method that returns a Resource (or a subtype) will be handled by the Hal Converter and rendered in HAL.

It turns out returning List<Resource> is not supported and must be put in a Resources-object. It is not possible in HAL to return a list of something. It has to be wrapped in a top level resource. See following links:

* https://stackoverflow.com/questions/28139856/how-can-i-get-spring-mvchateoas-to-encode-a-list-of-resources-into-hal
* https://github.com/spring-projects/spring-hateoas/issues/709

So putting a list of, for instance ApplicationDeploymentDetailsResource, in a Resources object will change the json representation to something like:

```
{
  "_embedded": {
    "applicationDeploymentDetailsResourceList": [
      {
        "buildTime": null,
        "gitInfo": {
          "commitId": null,
          "commitTime": null
        },
        "imageDetails": {
          "imageBuildTime": "2018-10-23T12:39:18Z",
          "dockerImageReference": "docker-registry.aurora.sits.no:5000/no_skatteetaten_aurora/gobo@sha256:fc09b9ea49a0b92ba2e769e10c70202eb74d42b34df614c6c1db3a73b129867d"
        },
        "podResources": [
          {
            "name": "gobo-29-lxsv5",
            "status": "Running",
            "restartCount": 0,
            "ready": true,
            "startTime": "2018-10-23T13:27:27Z",
            "managementResponses": null,
            "_links": {
              "ocp_console_details": {
                "href": "https://utv-master.paas.skead.no:8443/console/project/aurora-dev/browse/pods/gobo-29-lxsv5?tab=details"
              },
              "ocp_console_environment": {
                "href": "https://utv-master.paas.skead.no:8443/console/project/aurora-dev/browse/pods/gobo-29-lxsv5?tab=environment"
              },
              "ocp_console_terminal": {
                "href": "https://utv-master.paas.skead.no:8443/console/project/aurora-dev/browse/pods/gobo-29-lxsv5?tab=terminal"
              },
              "ocp_console_events": {
                "href": "https://utv-master.paas.skead.no:8443/console/project/aurora-dev/browse/pods/gobo-29-lxsv5?tab=events"
              },
              "ocp_console_log": {
                "href": "https://utv-master.paas.skead.no:8443/console/project/aurora-dev/browse/pods/gobo-29-lxsv5?tab=log"
              }
            }
          }
        ],
        ...
```

from the original (actuall not HAL compliant):

```
[
  {
    "buildTime": "2018-10-23T13:29:24.129Z",
    "gitInfo": {
      "commitId": null,
      "commitTime": null
    },
    "imageDetails": {
      "imageBuildTime": "2018-10-23T13:30:11Z",
      "dockerImageReference": "docker-registry.aurora.sits.no:5000/no_skatteetaten_aurora/mokey@sha256:b4a4cddf1d5818cb17d2a68ebe95d7d44e9248c74e126b1c514fa57570f8f1c2"
    },
    "podResources": [
      {
        "name": "mokey-55-7bbfr",
        "status": "Running",
        "restartCount": 0,
        "ready": true,
        "startTime": "2018-10-23T13:32:12Z",
        "managementResponses": {
          "health": {
            "textResponse": "{\n  \"status\" : \"UP\",\n  \"details\" : {\n    \"diskSpace\" : {\n      \"status\" : \"UP\",\n      \"details\" : {\n        \"total\" : 10726932480,\n        \"free\" : 10432909312,\n        \"threshold\" : 10485760\n      }\n    }\n  }\n}",
            "createdAt": "2018-10-25T12:24:40.373Z"
          },
          "info": {
            "textResponse": "{\n  \"serviceLinks\" : {\n    \"metrics\" : \"{metricsHostname}/dashboard/db/openshift-project-spring-actuator-view?var-ds=openshift-{cluster}-ose&var-namespace={namespace}&var-app={name}\"\n  },\n  \"podLinks\" : {\n    \"metrics\" : \"{metricsHostname}/dashboard/db/openshift-project-spring-actuator-view-instance?var-ds=openshift-{cluster}-ose&var-namespace={namespace}&var-app={name}&var-instance={podName}\"\n  },\n  \"auroraVersion\" : \"2.3.0-b1.17.0-yeaster-1.0.8\",\n  \"imageBuildTime\" : \"2018-10-23T13:30:11Z\",\n  \"build\" : {\n    \"version\" : \"2.3.0\",\n    \"artifact\" : \"mokey\",\n    \"name\" : \"mokey\",\n    \"group\" : \"no.skatteetaten.aurora\",\n    \"time\" : \"2018-10-23T13:29:24.129Z\"\n  }\n}",
            "createdAt": "2018-10-25T12:24:40.371Z"
          }
        },
        "_links": {
          "metrics": {
            "href": "http://metrics.skead.no/dashboard/db/openshift-project-spring-actuator-view-instance?var-ds=openshift-utv-ose&var-namespace=aurora&var-app=mokey&var-instance=mokey-55-7bbfr"
          },
          "ocp_console_details": {
            "href": "https://utv-master.paas.skead.no:8443/console/project/aurora/browse/pods/mokey-55-7bbfr?tab=details"
          },
          "ocp_console_environment": {
            "href": "https://utv-master.paas.skead.no:8443/console/project/aurora/browse/pods/mokey-55-7bbfr?tab=environment"
          },
          "ocp_console_terminal": {
            "href": "https://utv-master.paas.skead.no:8443/console/project/aurora/browse/pods/mokey-55-7bbfr?tab=terminal"
          },
          "ocp_console_events": {
            "href": "https://utv-master.paas.skead.no:8443/console/project/aurora/browse/pods/mokey-55-7bbfr?tab=events"
          },
          "ocp_console_log": {
            "href": "https://utv-master.paas.skead.no:8443/console/project/aurora/browse/pods/mokey-55-7bbfr?tab=log"
          }
        }
      }
    ],
    "dependencies": {},
    "applicationDeploymentCommand": {
      "applicationDeploymentRef": {
        "environment": "utv",
        "application": "mokey"
      },
```

So... fixing this will also require a fix in gobo.

If accepting this pr. it cannot be merged before gobo has also been updated.