### PR TITLE
Feature/aos 2871 health errors OBSOLETE

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentDetailsController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentDetailsController.kt
@@ -121,7 +121,6 @@ class ApplicationDeploymentDetailsResourceAssembler(val linkBuilder: LinkBuilder
             mgmtData.value?.let {
                 HttpResponseResource(hasResponse = true, textResponse = it.textResponse, createdAt = it.createdAt)
             } ?: HttpResponseResource(hasResponse = false, error = toErrorResource(PodError(podDetails, nullSafeManagementEndpointError(endpoint))))
-
         } else {
             mgmtData.error?.let {
                 HttpResponseResource(hasResponse = false, error = toErrorResource(PodError(podDetails, it)))
@@ -162,7 +161,7 @@ class ApplicationDeploymentDetailsResourceAssembler(val linkBuilder: LinkBuilder
     }
 
     private fun nullSafeManagementEndpointError(endpoint: Endpoint): ManagementEndpointError {
-        return ManagementEndpointError(message = "Endpoint error is null", endpointType = endpoint, code= "API_ERROR")
+        return ManagementEndpointError(message = "Endpoint error is null", endpointType = endpoint, code = "API_ERROR")
     }
 
     private fun createApplicationLinks(applicationData: ApplicationData): List<Link> {

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/resources.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/resources.kt
@@ -86,8 +86,10 @@ class PodResource(
 ) : ResourceSupport()
 
 data class HttpResponseResource(
-    val textResponse: String,
-    val createdAt: Instant
+    val hasResponse: Boolean,
+    val textResponse: String? = null,
+    val createdAt: Instant? = null,
+    val error: ManagementEndpointErrorResource? = null
 )
 
 data class ManagementResponsesResource(

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/service/ManagementDataService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/service/ManagementDataService.kt
@@ -35,7 +35,7 @@ class ManagementDataService(val managementEndpointFactory: ManagementEndpointFac
             val managementEndpoint = managementEndpointFactory.create(url)
             val infoEndpointResponse = managementEndpoint.getInfoEndpointResponse()
             val healthEndpointResponse = managementEndpoint.getHealthEndpointResponse()
-            Right(ManagementData(managementEndpoint.links, Right(infoEndpointResponse), Right(healthEndpointResponse)))
+            Right(ManagementData(managementEndpoint.links, infoEndpointResponse, healthEndpointResponse))
         } catch (e: ManagementEndpointException) {
             Left(ManagementEndpointError("Error while communicating with management endpoint",
                     e.endpoint, e.errorCode, e.cause?.message, url = url))

--- a/src/test/kotlin/no/skatteetaten/aurora/mokey/service/ManagementDataServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/mokey/service/ManagementDataServiceTest.kt
@@ -14,6 +14,7 @@ import no.skatteetaten.aurora.mokey.model.InfoResponse
 import no.skatteetaten.aurora.mokey.model.ManagementLinks
 import no.skatteetaten.aurora.utils.Left
 import no.skatteetaten.aurora.utils.Right
+import no.skatteetaten.aurora.utils.value
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -58,8 +59,8 @@ class ManagementDataServiceTest {
 
     @Test
     fun `Load management endpoint`() {
-        every { managementEndpoint.getInfoEndpointResponse() } returns HttpResponse(InfoResponse(), "")
-        every { managementEndpoint.getHealthEndpointResponse() } returns HttpResponse(HealthResponse(status = HealthStatus.UP), "")
+        every { managementEndpoint.getInfoEndpointResponse() } returns Right(HttpResponse(InfoResponse(), ""))
+        every { managementEndpoint.getHealthEndpointResponse() } returns Right(HttpResponse(HealthResponse(status = HealthStatus.UP), ""))
         every { managementEndpoint.links } returns ManagementLinks(emptyMap())
         every { managementEndpointFactory.create(any()) } returns managementEndpoint
 


### PR DESCRIPTION
PR for AOS-2871 / AOS-2941. 

Main changes: 

- Included optional ManagementEndpointErrorResource in HttpResponseResource.
- Changed exception login in ManagementDataService.load(). If info or health endpoints fails, then an ManagementEndpointErrorResource is included in the corresponding HttpResponseResource.