### PR TITLE
AOS-4831 added endpoint to get ADs Refs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,17 +8,17 @@ plugins {
     id("org.springframework.cloud.contract")
     id("org.jetbrains.kotlin.jvm") version "1.3.72"
     id("org.jetbrains.kotlin.plugin.spring") version "1.3.72"
-    id("org.springframework.boot") version "2.2.6.RELEASE"
+    id("org.springframework.boot") version "2.3.3.RELEASE"
 
     id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
-    id("org.sonarqube") version "2.8"
+    id("org.sonarqube") version "3.0"
     id("org.asciidoctor.convert") version "2.4.0"
-    id("com.gorylenko.gradle-git-properties") version "2.2.2"
-    id("com.github.ben-manes.versions") version "0.28.0"
-    id("se.patrikerdes.use-latest-versions") version "0.2.13"
-    id("com.adarshr.test-logger") version "2.0.0"
+    id("com.gorylenko.gradle-git-properties") version "2.2.3"
+    id("com.github.ben-manes.versions") version "0.29.0"
+    id("se.patrikerdes.use-latest-versions") version "0.2.14"
+    id("com.adarshr.test-logger") version "2.1.0"
 
-    id("no.skatteetaten.gradle.aurora") version "3.5.2"
+    id("no.skatteetaten.gradle.aurora") version "3.6.7"
 }
 
 dependencies {
@@ -26,7 +26,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.3.4")
     implementation("io.projectreactor.addons:reactor-extra:3.3.3.RELEASE")
     implementation("no.skatteetaten.aurora.kubernetes:kubernetes-reactor-coroutines-client:1.3.0")
-    implementation("com.github.ben-manes.caffeine:caffeine:2.8.1")
+    implementation("com.github.ben-manes.caffeine:caffeine:2.8.5")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -38,15 +38,15 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("uk.q3c.rest:hal-kotlin:0.5.4.0.db32476")
     implementation("com.jayway.jsonpath:json-path:2.4.0")
-    implementation("org.apache.commons:commons-lang3:3.10")
+    implementation("org.apache.commons:commons-lang3:3.11")
 
     testImplementation("io.mockk:mockk:1.10.0")
-    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.21")
+    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.22")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
     testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.1.4")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.5.0")
-    testImplementation("com.squareup.okhttp3:okhttp:4.5.0")
-    testImplementation("com.ninja-squad:springmockk:2.0.1")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.8.1")
+    testImplementation("com.squareup.okhttp3:okhttp:4.8.1")
+    testImplementation("com.ninja-squad:springmockk:2.0.3")
 }
 
 testlogger {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.10.0")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.21")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
-    testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.0.13")
+    testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.1.4")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.5.0")
     testImplementation("com.squareup.okhttp3:okhttp:4.5.0")
     testImplementation("com.ninja-squad:springmockk:2.0.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ version=local-SNAPSHOT
 groupId=no.skatteetaten.aurora
 artifactId=mokey
 aurora.applyCheckstylePlugin=false
-aurora.springCloudContractVersion=2.1.3.RELEASE
+aurora.springCloudContractVersion=2.2.4.RELEASE

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-6.2-bin.zip
+distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentController.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentController.kt
@@ -1,5 +1,6 @@
 package no.skatteetaten.aurora.mokey.controller
 
+import no.skatteetaten.aurora.mokey.model.ApplicationDeploymentRef
 import no.skatteetaten.aurora.mokey.model.ApplicationPublicData
 import no.skatteetaten.aurora.mokey.model.Environment
 import no.skatteetaten.aurora.mokey.model.StatusCheckReport
@@ -7,6 +8,8 @@ import no.skatteetaten.aurora.mokey.service.ApplicationDataService
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.q3c.rest.hal.HalLink
@@ -28,6 +31,13 @@ class ApplicationDeploymentController(
             applicationDataService.findPublicApplicationDataByApplicationDeploymentId(id)
                 ?: throw NoSuchResourceException("Does not exist")
         return assembler.toResource(application)
+    }
+
+    @PostMapping
+    fun getApplicationDeploymentForRefs(@RequestBody applicationDeploymentRefs: List<ApplicationDeploymentRef>): List<ApplicationDeploymentResource> {
+        val applications =
+            applicationDataService.findPublicApplicationDataByApplicationDeploymentRef(applicationDeploymentRefs)
+        return assembler.toResources(applications)
     }
 }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/mokey/service/ApplicationDataService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/mokey/service/ApplicationDataService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withTimeout
 import mu.KotlinLogging
 import no.skatteetaten.aurora.mokey.model.ApplicationData
 import no.skatteetaten.aurora.mokey.model.ApplicationDeployment
+import no.skatteetaten.aurora.mokey.model.ApplicationDeploymentRef
 import no.skatteetaten.aurora.mokey.model.ApplicationPublicData
 import no.skatteetaten.aurora.mokey.model.Environment
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -39,6 +40,13 @@ class ApplicationDataService(
      */
     fun findPublicApplicationDataByApplicationDeploymentId(id: String): ApplicationPublicData? {
         return cache[id]?.publicData
+    }
+
+    fun findPublicApplicationDataByApplicationDeploymentRef(applicationDeploymentRefs: List<ApplicationDeploymentRef>): List<ApplicationPublicData> {
+        return cache.filter {
+            val publicData = it.value.publicData
+            applicationDeploymentRefs.contains(ApplicationDeploymentRef(publicData.environment, publicData.applicationName))
+        }.ifEmpty { return emptyList() }.values.map { it.publicData }
     }
 
     fun findAllPublicApplicationDataByApplicationId(id: String): List<ApplicationPublicData> =

--- a/src/test/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentControllerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/mokey/controller/ApplicationDeploymentControllerTest.kt
@@ -3,15 +3,19 @@ package no.skatteetaten.aurora.mokey.controller
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import no.skatteetaten.aurora.mockmvc.extensions.Path
+import no.skatteetaten.aurora.mockmvc.extensions.contentTypeJson
 import no.skatteetaten.aurora.mockmvc.extensions.get
+import no.skatteetaten.aurora.mockmvc.extensions.post
 import no.skatteetaten.aurora.mockmvc.extensions.responseJsonPath
 import no.skatteetaten.aurora.mockmvc.extensions.status
 import no.skatteetaten.aurora.mockmvc.extensions.statusIsOk
 import no.skatteetaten.aurora.mokey.AbstractSecurityControllerTest
 import no.skatteetaten.aurora.mokey.ApplicationDataBuilder
 import no.skatteetaten.aurora.mokey.ApplicationDeploymentResourceBuilder
+import no.skatteetaten.aurora.mokey.model.ApplicationDeploymentRef
 import no.skatteetaten.aurora.mokey.service.ApplicationDataService
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 
 class ApplicationDeploymentControllerTest : AbstractSecurityControllerTest() {
@@ -29,6 +33,22 @@ class ApplicationDeploymentControllerTest : AbstractSecurityControllerTest() {
 
         mockMvc.get(Path("/api/applicationdeployment/{id}", "123")) {
             statusIsOk().responseJsonPath("$.identifier").equalsValue("123")
+        }
+    }
+
+    @Test
+    fun `Return application deployments by refs`() {
+        every { applicationDataService.findPublicApplicationDataByApplicationDeploymentRef(any()) } returns listOf(
+            ApplicationDataBuilder().build().publicData
+        )
+        every { assembler.toResources(any()) } returns listOf(ApplicationDeploymentResourceBuilder().build())
+
+        mockMvc.post(
+            path = Path("/api/applicationdeployment"),
+            body = listOf(ApplicationDeploymentRef("environment", "application")),
+        headers = HttpHeaders().contentTypeJson()
+        ) {
+            statusIsOk().responseJsonPath("$[0].identifier").equalsValue("123")
         }
     }
 

--- a/src/test/kotlin/no/skatteetaten/aurora/mokey/service/ApplicationDataServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/mokey/service/ApplicationDataServiceTest.kt
@@ -169,7 +169,7 @@ class ApplicationDataServiceTest {
     }
 
     @Test
-    fun `Return null if no ApplicationDeployment is found`() {
+    fun `Return empty list if no ApplicationDeployment is found`() {
         val applicationData = dataService.findPublicApplicationDataByApplicationDeploymentRef(
             listOf(ApplicationDeploymentRef("unknown", "unknown"))
         )


### PR DESCRIPTION
Why `post`? The endpoints that gobo uses should support list input, to be able to get multiple values at once. This makes it possible to write data loaders in graphql and avoiding a lot of requests. With `post` we can send the input values in the body of the request (it is possible with `get` as well, but not recommended). It can also be a problem to put the values as query params, due to the length limit.